### PR TITLE
Update suite2p pipeline to save meanImg as png

### DIFF
--- a/photon_mosaic/workflow/suite2p.smk
+++ b/photon_mosaic/workflow/suite2p.smk
@@ -64,7 +64,7 @@ rule suite2p:
     resources:
         **(slurm_config if config.get("use_slurm") else {}),
     run:
-        from photon_mosaic.rules.suite2p_run import run_suite2p
+        from photon_mosaic.rules.suite2p_run import run_suite2p, save_suite2p_meanImgs
         from pathlib import Path
 
         # Ensure all paths are properly resolved
@@ -72,8 +72,11 @@ rule suite2p:
         output_path = Path(output.F).resolve()
         dataset_folder = Path(params.dataset_folder).resolve()
 
-        run_suite2p(
+        ops = run_suite2p(
             str(output_path),
             dataset_folder,
             config["suite2p_ops"],
         )
+
+        # Suite2p Extension
+        save_suite2p_meanImgs(ops)


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

**What does this PR do?**
This PR adds an extension of the Suite2p pipeline, which allows users to save meanImg as PNG files. This fixes #44

## References
This clean PR was made after #46

## Is this a breaking change?
 A path to save the files is hard-coded at the moment, expecting there is only one plane imaged.

## Does this PR require an update to the documentation?
Yes, though the documention has not been updated

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
