### PR TITLE
Update `_is_neuroblueprint_format()` to strictly verify neuroblueprint format

### DIFF
--- a/photon_mosaic/dataset_discovery.py
+++ b/photon_mosaic/dataset_discovery.py
@@ -299,7 +299,7 @@ class DatasetDiscoverer:
 
         # First part should be prefix-identifier
         first_part = parts[0]
-        if not re.match(rf"{expected_prefix}-\d+", first_part):
+        if not re.fullmatch(rf"{expected_prefix}-\d+", first_part):
             return False
 
         # Remaining parts should be key-value pairs

--- a/tests/test_unit/test_metadata.py
+++ b/tests/test_unit/test_metadata.py
@@ -197,6 +197,8 @@ class TestMetadataFunctionality:
             "sub-001_-value",  # Missing key before value
             "sub-mouse123_genotype-WT_age-P60",  # Alphanumeric ID not allowed
             "ses-baseline_condition-control",  # Alphanumeric ID not allowed
+            "ses-task001",  # Alphanumeric ID not allowed
+            "ses-001task",  # Alphanumeric ID not allowed
         ]
 
         for name in invalid_names:


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Currently, photon-mosaic supports datasets in either the neuroblueprint format or a custom format. However, the dataset discovery process does not strictly verify whether a dataset truly follows the neuroblueprint format. This can cause the pipeline to fail when later components assume a strictly neuroblueprint-compliant structure.

**What does this PR do?**
This PR updates `_is_neuroblueprint_format()` to verify that the datasets use integer subject and session IDs. Since other parts of the code assume that datasets passing this check have integer session IDs, this change should not affect existing behavior.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
