### PR TITLE
docs: remove --unlock otpion and update description

### DIFF
--- a/docs/source/user_guide/snakemake_tutorial.md
+++ b/docs/source/user_guide/snakemake_tutorial.md
@@ -63,7 +63,6 @@ Other useful arguments you can pass:
 
 - `--latency-wait`: wait time before checking if output files are ready
 - `--rerun-incomplete`: rerun any incomplete jobs
-- `--unlock`: unlock the workflow if it's in a locked state
 
 ## Direct Snakemake Usage
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Other (documentation update)

**Why is this PR needed?**

The documentation still references the `--unlock` CLI argument, which no longer exists since unlocking is now handled automatically by photon-mosaic. This outdated reference may confuse users.

**What does this PR do?**

This PR removes the obsolete `--unlock` option from the Snakemake tutorial documentation and updates the page to reflect the current set of supported CLI arguments.

## References

No related issues or PRs were found, but this PR resolves the incorrect documentation identified by the maintainers.

## How has this PR been tested?

No code changes were made.  
The documentation was reviewed locally to ensure correct formatting and clarity.

## Is this a breaking change?

No.  
This PR only modifies documentation and does not affect existing functionality.

## Does this PR require an update to the documentation?

This PR *is* the required documentation update.

## Checklist:

- [x] The documentation has been updated to reflect any changes  
- [ ] The code has been tested locally (N/A – no code changes)  
- [ ] Tests have been added (N/A – no code changes)  
- [ ] The code has been formatted with pre-commit (optional for docs edits)
