### PR TITLE
Update Dataset discovery sorting to use file creation time

### DIFF
--- a/photon_mosaic/dataset_discovery.py
+++ b/photon_mosaic/dataset_discovery.py
@@ -7,6 +7,7 @@ All filtering and transformations are handled through regex substitutions.
 """
 
 import logging
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -837,8 +838,17 @@ class DatasetDiscoverer:
                     )
                 )
 
+                session_folders_sorted = sorted(
+                    custom_session_folders,
+                    key=lambda p: (
+                        p.stat().st_ctime
+                        if isinstance(p, Path)
+                        else os.path.getctime(str(p))
+                    ),
+                )
+
                 # Process each session folder
-                for session_folder in sorted(custom_session_folders):
+                for session_folder in session_folders_sorted:
                     # Extract session ID from folder name (look for
                     # session-XXX pattern)
                     session_id_match = re.search(

--- a/photon_mosaic/dataset_discovery.py
+++ b/photon_mosaic/dataset_discovery.py
@@ -266,7 +266,11 @@ class DatasetDiscoverer:
                     key, value = part.split("-", 1)
                     # Skip 'sub', 'ses', and 'session' as they are structural,
                     # not metadata
-                    if accept_structural or key not in ["sub", "ses", "session"]:
+                    if accept_structural or key not in [
+                        "sub",
+                        "ses",
+                        "session",
+                    ]:
                         # Create a flexible regex pattern for this key
                         metadata_patterns[key] = f"{key}-([^_]+)"
 
@@ -829,7 +833,7 @@ class DatasetDiscoverer:
                 inferred_metadata = (
                     self._infer_metadata_keys_from_folder_names(
                         [s.name for s in custom_session_folders],
-                        accept_structural=True
+                        accept_structural=True,
                     )
                 )
 

--- a/photon_mosaic/dataset_discovery.py
+++ b/photon_mosaic/dataset_discovery.py
@@ -239,6 +239,7 @@ class DatasetDiscoverer:
     @staticmethod
     def _infer_metadata_keys_from_folder_names(
         folder_names: List[str],
+        accept_structural: bool = False,
     ) -> Dict[str, str]:
         """
         Automatically infer metadata keys and patterns from actual folder
@@ -265,7 +266,7 @@ class DatasetDiscoverer:
                     key, value = part.split("-", 1)
                     # Skip 'sub', 'ses', and 'session' as they are structural,
                     # not metadata
-                    if key not in ["sub", "ses", "session"]:
+                    if accept_structural or key not in ["sub", "ses", "session"]:
                         # Create a flexible regex pattern for this key
                         metadata_patterns[key] = f"{key}-([^_]+)"
 
@@ -299,7 +300,7 @@ class DatasetDiscoverer:
 
         # First part should be prefix-identifier
         first_part = parts[0]
-        if not re.match(rf"{expected_prefix}-[a-zA-Z0-9]+", first_part):
+        if not re.fullmatch(rf"{expected_prefix}-\d+", first_part):
             return False
 
         # Remaining parts should be key-value pairs
@@ -827,7 +828,8 @@ class DatasetDiscoverer:
                 # Infer metadata patterns from session folder names
                 inferred_metadata = (
                     self._infer_metadata_keys_from_folder_names(
-                        [s.name for s in custom_session_folders]
+                        [s.name for s in custom_session_folders],
+                        accept_structural=True
                     )
                 )
 
@@ -860,6 +862,10 @@ class DatasetDiscoverer:
                             session_meta = self._extract_metadata_from_name(
                                 session_folder.name, inferred_metadata
                             )
+
+                            # Replace structural metadata keys to id
+                            for k in ["sub-", "ses-", "session-"]:
+                                session_meta = session_meta.replace(k, "id-")
 
                             # If no metadata could be inferred from a custom
                             # session folder (e.g. plain alphanumeric names

--- a/photon_mosaic/rules/dff_run.py
+++ b/photon_mosaic/rules/dff_run.py
@@ -1,0 +1,73 @@
+"""
+Snakemake rule for calculating dF/F.
+"""
+
+from pathlib import Path
+
+import numpy as np
+from sklearn import mixture
+
+
+def calculate_dFF(
+    input_path_F: str,
+    input_path_Fneu: str,
+    output_path: str,
+    user_ops_dict: dict,
+):
+    """
+    This function calculates dF/F for the whole session after neuropil
+    correction. It uses dF/F from suite2p outputs and saves the
+    results in the specified paths. This function is adapted from
+    https://github.com/znamlab/2p-preprocess/blob/f34c287d5830a3852fdf44f9bd8a826e70095471/twop_preprocess/calcium.py#L768
+
+    Parameters
+    ----------
+    input_path_F : str
+        The path where the F.npy from Suite2P is saved.
+    input_path_Fneu : str
+        The path where the Fneu.npy from Suite2P is saved.
+    output_path : str
+        The path where the dFF.npy and f0.npy will be saved.
+    user_ops_dict : dict, optional
+        A dictionary containing user-provided options to override
+        the default Suite2P options. The default is None.
+
+    Returns
+    -------
+    None
+        The function calculates dF/F and saves results to the specified paths.
+    """
+    save_folder = Path(output_path).parents[0]
+    save_folder.mkdir(parents=True, exist_ok=True)
+
+    print("Calculating dF/F...")
+
+    F = np.load(input_path_F)
+    Fneu = np.load(input_path_Fneu)
+    Fc = F - user_ops_dict["neucoeff"] * (
+        Fneu - np.median(Fneu, axis=1)[:, None]
+    )
+
+    print(
+        "n components for dFF calculation: {}".format(
+            user_ops_dict["gmm_ncomponents"]
+        )
+    )
+
+    dff, f0 = dFF(Fc, n_components=user_ops_dict["gmm_ncomponents"])
+
+    np.save(save_folder / "dFF.npy", dff)
+    np.save(save_folder / "F0.npy", f0)
+
+
+def dFF(f, n_components=2, random_state=42):
+    f0 = np.zeros(f.shape[0])
+    for i in range(f.shape[0]):
+        gmm = mixture.GaussianMixture(
+            n_components=n_components, random_state=random_state
+        ).fit(f[i].reshape(-1, 1))
+        gmm_means = np.sort(gmm.means_[:, 0])
+        f0[i] = gmm_means[0]
+    f0 = f0.reshape(-1, 1)
+    dff = (f - f0) / f0
+    return dff, f0

--- a/photon_mosaic/workflow/Snakefile
+++ b/photon_mosaic/workflow/Snakefile
@@ -2,14 +2,15 @@
 Photon Mosaic Main Workflow
 
 This is the main Snakefile that orchestrates the entire photon mosaic processing pipeline.
-It handles dataset discovery, target generation, and coordinates the preprocessing and
-suite2p analysis workflows.
+It handles dataset discovery, target generation, and coordinates the preprocessing,
+suite2p analysis, and dF/F calculation workflows.
 
 The workflow:
 1. Discovers datasets and their TIFF files from the raw data directory
 2. Generates preprocessing targets for each dataset/session combination
 3. Generates suite2p analysis targets for processed data
-4. Includes preprocessing.smk and suite2p.smk modules to execute the actual processing
+4. Generates dff calculation targets for processed data
+5. Includes preprocessing.smk, suite2p.smk, dff.smk modules to execute the actual processing
 """
 
 from pathlib import Path
@@ -102,12 +103,34 @@ suite2p_targets = [
 
 logger.info(f"Suite2p targets: {suite2p_targets}")
 
+dff_targets = [
+    str(
+        Path(processed_data_base)
+        / dataset_name
+        / discoverer.get_session_name(i, session_idx)
+        / "funcimg"
+        / "dff"
+        / "plane0"
+        / fname
+    )
+    for i, dataset_name in enumerate(discoverer.transformed_datasets)
+    for session_idx, tiff_list in discoverer.tiff_files[
+        discoverer.original_datasets[i]
+    ].items()
+    for fname in ["dFF.npy"]
+    if tiff_list  # Only create targets for sessions that have files
+]
+
+logger.info(f"dFF calculation targets: {dff_targets}")
+
 
 include: "preprocessing.smk"
 include: "suite2p.smk"
+include: "dff.smk"
 
 
 rule all:
     input:
         preproc_targets,
         suite2p_targets,
+        dff_targets,

--- a/photon_mosaic/workflow/config.yaml
+++ b/photon_mosaic/workflow/config.yaml
@@ -170,6 +170,14 @@ suite2p_ops:
   neucoeff: 0.7  # Neuropil coefficient
 
 # ============================================================================
+# dF/F Calculation Configuration
+# ============================================================================
+# Controls the dF/F calculation steps
+dff_ops:
+  neucoeff: 0.7  # Neuropil coefficient
+  gmm_ncomponents: 2 # Number of GMM components
+
+# ============================================================================
 # SLURM Configuration
 # ============================================================================
 # Settings for SLURM job scheduling system

--- a/photon_mosaic/workflow/dff.smk
+++ b/photon_mosaic/workflow/dff.smk
@@ -1,0 +1,85 @@
+"""
+dF/F Calculation Module
+
+This Snakefile module handles the dF/F calculation step of the photon mosaic pipeline.
+It takes Suite2p outputs and compute dF/F.
+
+The suite2p rule:
+- Takes preprocessed TIFF files as input (from preprocessing step)
+- Runs Suite2p analysis with parameters from config["suite2p_ops"]
+- Outputs F.npy (fluorescence traces) and data.bin (binary data) files
+- Supports SLURM cluster execution with configurable resources
+
+Input: Suite2p analysis results (F.npy, Fneu.npy) in suite2p/plane0/ directory
+Output: dff calculation results (dFF.npy) in dff/plane0/ directory
+"""
+
+import re
+from photon_mosaic.snakemake_utils import cross_platform_path
+
+
+rule dff:
+    input:
+        F=cross_platform_path(
+            Path(processed_data_base).resolve()
+            / "{subject_name}"
+            / "{session_name}"
+            / "funcimg"
+            / "suite2p"
+            / "plane0"
+            / "F.npy"
+        ),
+        Fneu=cross_platform_path(
+            Path(processed_data_base).resolve()
+            / "{subject_name}"
+            / "{session_name}"
+            / "funcimg"
+            / "suite2p"
+            / "plane0"
+            / "Fneu.npy"
+        ),
+    output:
+        dFF=cross_platform_path(
+            Path(processed_data_base).resolve()
+            / "{subject_name}"
+            / "{session_name}"
+            / "funcimg"
+            / "dff"
+            / "plane0"
+            / "dFF.npy"
+        ),
+    # params:
+    #     dataset_folder=lambda wildcards: cross_platform_path(
+    #         Path(processed_data_base).resolve()
+    #         / wildcards.subject_name
+    #         / wildcards.session_name
+    #         / "funcimg"
+    #     ),
+    wildcard_constraints:
+        subject_name="|".join(discoverer.transformed_datasets),
+        session_name="|".join(
+            [
+                discoverer.get_session_name(i, session_idx)
+                for i in range(len(discoverer.transformed_datasets))
+                for session_idx in discoverer.tiff_files[
+                    discoverer.original_datasets[i]
+                ].keys()
+            ]
+        ),
+    resources:
+        **(slurm_config if config.get("use_slurm") else {}),
+    run:
+        from photon_mosaic.rules.dff_run import calculate_dFF
+        from pathlib import Path
+
+        # Ensure all paths are properly resolved
+        input_path_F = Path(input.F).resolve()
+        input_path_Fneu = Path(input.Fneu).resolve()
+        output_path = Path(output.dFF).resolve()
+
+        calculate_dFF(
+            str(input_path_F),
+            str(input_path_Fneu),
+            str(output_path),
+            config["dff_ops"],
+        )

--- a/photon_mosaic/workflow/dff.smk
+++ b/photon_mosaic/workflow/dff.smk
@@ -29,15 +29,6 @@ rule dff:
             / "plane0"
             / "F.npy"
         ),
-        Fneu=cross_platform_path(
-            Path(processed_data_base).resolve()
-            / "{subject_name}"
-            / "{session_name}"
-            / "funcimg"
-            / "suite2p"
-            / "plane0"
-            / "Fneu.npy"
-        ),
     output:
         dFF=cross_platform_path(
             Path(processed_data_base).resolve()
@@ -48,13 +39,6 @@ rule dff:
             / "plane0"
             / "dFF.npy"
         ),
-    # params:
-    #     dataset_folder=lambda wildcards: cross_platform_path(
-    #         Path(processed_data_base).resolve()
-    #         / wildcards.subject_name
-    #         / wildcards.session_name
-    #         / "funcimg"
-    #     ),
     wildcard_constraints:
         subject_name="|".join(discoverer.transformed_datasets),
         session_name="|".join(

--- a/photon_mosaic/workflow/dff.smk
+++ b/photon_mosaic/workflow/dff.smk
@@ -58,7 +58,7 @@ rule dff:
 
         # Ensure all paths are properly resolved
         input_path_F = Path(input.F).resolve()
-        input_path_Fneu = Path(input.Fneu).resolve()
+        input_path_Fneu = Path(input.F).parent.resolve() / "Fneu.npy"
         output_path = Path(output.dFF).resolve()
 
         calculate_dFF(


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
`dataset_discovery.py` assigns session indices to TIFF files in custom datasets based on the sorted file names. This means that adding a newly generated file whose name sorts earlier than existing files can change the assigned session indices, which breaks the stability of session numbering.

**What does this PR do?**
This PR sorts the files based on the file creation date instead of file names. This PR is based on another PR #64, so please consider merging it first or rebasing this branch. **The test functions also need to be updated.**

## References
This PR will fix #70

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
