### PR TITLE
Pass runner's environment variables to tox test environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,8 @@ python =
 [testenv]
 deps =
     .[dev]
+passenv =
+    USERNAME
 commands =
     pytest -v --color=yes --cov=photon_mosaic --cov-report=xml
 """


### PR DESCRIPTION
Based on https://github.com/MouseLand/cellpose/pull/1411:

It looks like
* we import suite2p
* suite2p imports cellpose
* cellpose imports pytorch
* pytorch falls back on `pwd` if the environment variable USERNAME is not present

We had a similar [problem in cellfinder.](https://github.com/brainglobe/cellfinder/pull/577)

This PR fixes the problem by ensuring the Github runner passes its USERNAME environmental variable to the `tox` testing environment.