### PR TITLE
Add photostimulation artefact removal preprocessing

### DIFF
--- a/photon_mosaic/preprocessing/__init__.py
+++ b/photon_mosaic/preprocessing/__init__.py
@@ -9,4 +9,4 @@ from . import contrast
 from . import derotation
 from . import noop
 
-__all__ = ["contrast", "derotation", "noop"]
+__all__ = ["contrast", "derotation", "noop", "stiminterpolation"]

--- a/photon_mosaic/preprocessing/__init__.py
+++ b/photon_mosaic/preprocessing/__init__.py
@@ -1,12 +1,10 @@
 """
 Preprocessing module for photon-mosaic.
 
-This module provides preprocessing steps that can be applied to image data.
-Each preprocessing step is a function that takes an image array and returns a processed image array.
+Each preprocessing step is a function that takes an image array and
+returns a processed image array.
 """
 
-from . import contrast
-from . import derotation
-from . import noop
+from . import contrast, derotation, noop, stiminterpolation
 
 __all__ = ["contrast", "derotation", "noop", "stiminterpolation"]

--- a/photon_mosaic/preprocessing/stiminterpolation.py
+++ b/photon_mosaic/preprocessing/stiminterpolation.py
@@ -1,0 +1,115 @@
+"""
+Photonstimulation artefact removal step for photon-mosaic.
+
+This module provides a function to remove artefacts by holographic
+photostimulation using the stiminterp package.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+import tifffile
+from stiminterp import run_stiminterp
+
+logger = logging.getLogger(__name__)
+
+
+def run(
+    dataset_folder: Path,
+    output_folder: Path,
+    tiff_name: str,
+    path_to_stim_h5: str | None = None,
+    save_metadata: bool = True,
+    **kwargs,
+):
+    """
+    Photostimulation artefact removal using stiminterp.
+
+    Runs stiminterp on the input TIFF and saves the processed TIFF and its
+    ScanImage metadata as a JSON file to the output folder if required.
+
+    Parameters
+    ----------
+    dataset_folder : Path
+        Path to the dataset folder containing the input TIFF files.
+    output_folder : Path
+        Path to the output folder where symlinks will be created.
+    tiff_name : str
+        Name of the TIFF file to process.
+    path_to_stim_h5 : str | None
+        Path to the stimulation TTL HDF5 file. Defaults to None.
+    save_metadata : bool
+        Whether to save metadata as separate json file
+    **kwargs : dict
+        Additional keyword arguments for stiminterp pipeline.
+    """
+    # Convert paths to Path objects if they're strings
+    if isinstance(dataset_folder, str):
+        dataset_folder = Path(dataset_folder)
+    if isinstance(output_folder, str):
+        output_folder = Path(output_folder)
+
+    # Create output directory
+    output_folder.mkdir(parents=True, exist_ok=True)
+
+    # Define input and output paths
+    output_path = output_folder / f"stiminterpolated_{tiff_name}"
+
+    # Try to find the input file
+    input_file = dataset_folder / tiff_name
+    if not input_file.exists():
+        # Use rglob to find the file recursively
+        try:
+            input_file = next(dataset_folder.rglob(tiff_name))
+            logger.info(
+                f"Found input file using recursive search: {input_file}"
+            )
+        except StopIteration:
+            raise FileNotFoundError(
+                f"Could not find {tiff_name} in {dataset_folder}"
+            )
+
+    # Run stiminterp
+    logging.info(f"Running stiminterp pipeline for {str(input_file)}")
+    run_stiminterp(
+        input_tif=str(input_file),
+        input_h5=path_to_stim_h5,
+        output_tif=str(output_path),
+    )
+
+    # Save metadata as JSON
+    metadata = parse_si_metadata(input_file)
+    if metadata is not None:
+        json_path = output_path.with_name(output_path.stem + "_metadata.json")
+        with open(json_path, "w") as f:
+            json.dump(metadata, f, indent=4)
+        logger.info(f"Saved metadata to {json_path}")
+    else:
+        logger.warning(f"No ScanImage metadata found in {str(input_file)}")
+
+
+def parse_si_metadata(tiff_path):
+    """
+    Reads metadata from a Scanimage TIFF and return a dictionary with
+    specified key values.
+
+    Args:
+        tiff_path: path to TIFF or directory containing tiffs
+
+    Returns:
+        dict: dictionary of SI parameters
+
+    """
+    if tiff_path.suffix != ".tif":
+        tiffs = [tiff_path / tiff for tiff in sorted(tiff_path.glob("*.tif"))]
+    else:
+        tiffs = [
+            tiff_path,
+        ]
+    if tiffs:
+        metadata = tifffile.TiffFile(tiffs[0]).scanimage_metadata["FrameData"]
+    else:
+        metadata = None
+
+    return metadata

--- a/photon_mosaic/preprocessing/stiminterpolation.py
+++ b/photon_mosaic/preprocessing/stiminterpolation.py
@@ -72,6 +72,8 @@ def run(
 
     # Run stiminterp
     logging.info(f"Running stiminterp pipeline for {str(input_file)}")
+    if path_to_stim_h5 == "":
+        path_to_stim_h5 = None
     run_stiminterp(
         input_tif=str(input_file),
         input_h5=path_to_stim_h5,

--- a/photon_mosaic/preprocessing/stiminterpolation.py
+++ b/photon_mosaic/preprocessing/stiminterpolation.py
@@ -71,24 +71,28 @@ def run(
             )
 
     # Run stiminterp
-    logging.info(f"Running stiminterp pipeline for {str(input_file)}")
+    logger.info(f"Running stiminterp pipeline for {str(input_file)}")
     if path_to_stim_h5 == "":
         path_to_stim_h5 = None
     run_stiminterp(
         input_tif=str(input_file),
         input_h5=path_to_stim_h5,
         output_tif=str(output_path),
+        **kwargs,
     )
 
-    # Save metadata as JSON
-    metadata = parse_si_metadata(input_file)
-    if metadata is not None:
-        json_path = output_path.with_name(output_path.stem + "_metadata.json")
-        with open(json_path, "w") as f:
-            json.dump(metadata, f, indent=4)
-        logger.info(f"Saved metadata to {json_path}")
-    else:
-        logger.warning(f"No ScanImage metadata found in {str(input_file)}")
+    # Save metadata as JSON if requested
+    if save_metadata:
+        metadata = parse_si_metadata(input_file)
+        if metadata is not None:
+            json_path = output_path.with_name(
+                output_path.stem + "_metadata.json"
+            )
+            with open(json_path, "w") as f:
+                json.dump(metadata, f, indent=4)
+            logger.info(f"Saved metadata to {json_path}")
+        else:
+            logger.warning(f"No ScanImage metadata found in {str(input_file)}")
 
 
 def parse_si_metadata(tiff_path):

--- a/photon_mosaic/rules/preprocessing.py
+++ b/photon_mosaic/rules/preprocessing.py
@@ -26,8 +26,8 @@ def run_preprocessing(
     ses_idx : int, optional
         Session index to process. Default is 0.
     tiff_name : str, optional
-        Name of the TIFF file to process. Required for 'noop' and 'contrast'
-        preprocessing steps.
+        Name of the TIFF file to process. Required for 'noop', 'contrast',
+        and 'stiminterpolation' preprocessing steps.
 
     Returns
     -------

--- a/photon_mosaic/workflow/config.yaml
+++ b/photon_mosaic/workflow/config.yaml
@@ -39,9 +39,9 @@ preprocessing:
     # Photostimulation-artefact removal by interpolation
     # - name: stiminterpolation
     #   kwargs:
-    #     # File pattern matching for input files (HDF5)
-    #     path_to_stim_h5: "/Users/skuroda/local_data/stimlus_ttl.h5"
-    #     save_metadata: true # Whether to save metadata as separate json files
+    #     # Path to the stimulation TTL HDF5 file
+    #     path_to_stim_h5: "path/to/stimulus_ttl.h5"
+    #     save_metadata: true # Whether to save ScanImage metadata as a JSON file
 
     # Derotation
     # - name: derotation

--- a/photon_mosaic/workflow/config.yaml
+++ b/photon_mosaic/workflow/config.yaml
@@ -28,13 +28,20 @@ dataset_discovery:
 preprocessing:
   # Output file naming pattern for preprocessed files
   # Use a suffix relevant for the set of operations you want to perform
-  output_pattern: "" # "" for noop, "enhanced_" for contrast and "derotated_" for derotation
+  output_pattern: "" # "" for noop, "enhanced_" for contrast, "derotated_" for derotation, and "stiminterpolated_" for stiminterpolation
 
   # Define preprocessing steps and their parameters
   # They are mutually exclusive
   steps:
     # No operation, just copy the files
     - name: noop
+
+    # Photostimulation-artefact removal by interpolation
+    # - name: stiminterpolation
+    #   kwargs:
+    #     # File pattern matching for input files (HDF5)
+    #     path_to_stim_h5: "/Users/skuroda/local_data/stimlus_ttl.h5"
+    #     save_metadata: true # Whether to save metadata as separate json files
 
     # Derotation
     # - name: derotation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
   "PyYAML",
   "datashuttle",
   "derotation",
-  "suite2p-NIU"
+  "suite2p-NIU",
+  "stiminterp"
 ]
 
 license = {text = "BSD-3-Clause"}

--- a/tests/test_unit/test_stiminterpolation.py
+++ b/tests/test_unit/test_stiminterpolation.py
@@ -1,0 +1,225 @@
+"""
+Unit tests for the stiminterpolation preprocessing step.
+
+The tests mock the external `run_stiminterp` and ScanImage metadata parser
+so they exercise the orchestration layer (file discovery, kwargs threading,
+save_metadata gating, error paths) without needing a real TIFF or HDF5
+file with photostimulation artefacts.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from photon_mosaic.preprocessing import stiminterpolation
+
+
+def _create_dummy_tiff(path):
+    """Write a minimal placeholder file at `path` so .exists() is True.
+
+    The contents don't matter — every test that touches them mocks
+    parse_si_metadata or run_stiminterp.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"")
+
+
+@patch("photon_mosaic.preprocessing.stiminterpolation.parse_si_metadata")
+@patch("photon_mosaic.preprocessing.stiminterpolation.run_stiminterp")
+def test_run_calls_run_stiminterp_with_expected_args(
+    mock_run, mock_parse, tmp_path
+):
+    """Happy path: run_stiminterp is called with the resolved input/output
+    paths and the configured h5 path."""
+    dataset_folder = tmp_path / "rawdata"
+    output_folder = tmp_path / "out"
+    tiff_name = "recording.tif"
+    _create_dummy_tiff(dataset_folder / tiff_name)
+    mock_parse.return_value = {"FrameRate": 30.0}
+
+    stiminterpolation.run(
+        dataset_folder=dataset_folder,
+        output_folder=output_folder,
+        tiff_name=tiff_name,
+        path_to_stim_h5="/path/to/ttl.h5",
+        save_metadata=True,
+    )
+
+    mock_run.assert_called_once_with(
+        input_tif=str(dataset_folder / tiff_name),
+        input_h5="/path/to/ttl.h5",
+        output_tif=str(output_folder / "stiminterpolated_recording.tif"),
+    )
+
+
+@patch("photon_mosaic.preprocessing.stiminterpolation.parse_si_metadata")
+@patch("photon_mosaic.preprocessing.stiminterpolation.run_stiminterp")
+def test_run_threads_kwargs_through_to_stiminterp(
+    mock_run, mock_parse, tmp_path
+):
+    """Extra kwargs in the user config must reach run_stiminterp.
+
+    Regression guard: the original implementation accepted **kwargs but
+    never passed them on, so user-provided stiminterp parameters were
+    silently dropped.
+    """
+    dataset_folder = tmp_path / "rawdata"
+    output_folder = tmp_path / "out"
+    tiff_name = "recording.tif"
+    _create_dummy_tiff(dataset_folder / tiff_name)
+    mock_parse.return_value = None
+
+    stiminterpolation.run(
+        dataset_folder=dataset_folder,
+        output_folder=output_folder,
+        tiff_name=tiff_name,
+        path_to_stim_h5=None,
+        save_metadata=False,
+        threshold=0.5,
+        n_pre_frames=3,
+    )
+
+    _, kwargs = mock_run.call_args
+    assert kwargs["threshold"] == 0.5
+    assert kwargs["n_pre_frames"] == 3
+
+
+@patch("photon_mosaic.preprocessing.stiminterpolation.parse_si_metadata")
+@patch("photon_mosaic.preprocessing.stiminterpolation.run_stiminterp")
+def test_save_metadata_true_writes_json(mock_run, mock_parse, tmp_path):
+    """save_metadata=True writes the metadata JSON beside the output."""
+    dataset_folder = tmp_path / "rawdata"
+    output_folder = tmp_path / "out"
+    tiff_name = "recording.tif"
+    _create_dummy_tiff(dataset_folder / tiff_name)
+    mock_parse.return_value = {"FrameRate": 30.0, "ZoomFactor": 2.0}
+
+    stiminterpolation.run(
+        dataset_folder=dataset_folder,
+        output_folder=output_folder,
+        tiff_name=tiff_name,
+        save_metadata=True,
+    )
+
+    json_path = output_folder / "stiminterpolated_recording_metadata.json"
+    assert json_path.exists()
+    assert json.loads(json_path.read_text()) == {
+        "FrameRate": 30.0,
+        "ZoomFactor": 2.0,
+    }
+
+
+@patch("photon_mosaic.preprocessing.stiminterpolation.parse_si_metadata")
+@patch("photon_mosaic.preprocessing.stiminterpolation.run_stiminterp")
+def test_save_metadata_false_skips_json(mock_run, mock_parse, tmp_path):
+    """save_metadata=False suppresses the JSON write entirely.
+
+    Regression guard: the original implementation always saved metadata
+    regardless of this flag.
+    """
+    dataset_folder = tmp_path / "rawdata"
+    output_folder = tmp_path / "out"
+    tiff_name = "recording.tif"
+    _create_dummy_tiff(dataset_folder / tiff_name)
+
+    stiminterpolation.run(
+        dataset_folder=dataset_folder,
+        output_folder=output_folder,
+        tiff_name=tiff_name,
+        save_metadata=False,
+    )
+
+    # parse_si_metadata must not even be called when save_metadata is False
+    mock_parse.assert_not_called()
+    json_path = output_folder / "stiminterpolated_recording_metadata.json"
+    assert not json_path.exists()
+
+
+@patch("photon_mosaic.preprocessing.stiminterpolation.parse_si_metadata")
+@patch("photon_mosaic.preprocessing.stiminterpolation.run_stiminterp")
+def test_run_finds_tiff_via_recursive_search(mock_run, mock_parse, tmp_path):
+    """When the TIFF isn't directly under dataset_folder, rglob finds it."""
+    dataset_folder = tmp_path / "rawdata"
+    nested = dataset_folder / "sub-001" / "ses-001" / "funcimg"
+    tiff_name = "recording.tif"
+    _create_dummy_tiff(nested / tiff_name)
+    output_folder = tmp_path / "out"
+    mock_parse.return_value = None
+
+    stiminterpolation.run(
+        dataset_folder=dataset_folder,
+        output_folder=output_folder,
+        tiff_name=tiff_name,
+        save_metadata=False,
+    )
+
+    _, kwargs = mock_run.call_args
+    assert kwargs["input_tif"] == str(nested / tiff_name)
+
+
+def test_run_raises_when_tiff_missing(tmp_path):
+    """Missing TIFF (top-level + nested) raises FileNotFoundError."""
+    dataset_folder = tmp_path / "rawdata"
+    dataset_folder.mkdir()
+    output_folder = tmp_path / "out"
+
+    with pytest.raises(FileNotFoundError, match="missing.tif"):
+        stiminterpolation.run(
+            dataset_folder=dataset_folder,
+            output_folder=output_folder,
+            tiff_name="missing.tif",
+            save_metadata=False,
+        )
+
+
+@patch("photon_mosaic.preprocessing.stiminterpolation.parse_si_metadata")
+@patch("photon_mosaic.preprocessing.stiminterpolation.run_stiminterp")
+def test_empty_string_h5_is_passed_as_none(mock_run, mock_parse, tmp_path):
+    """An empty `path_to_stim_h5` in YAML is treated as None.
+
+    A YAML `path_to_stim_h5: ""` should not reach run_stiminterp as a
+    literal empty string — it would fail the file-open downstream.
+    """
+    dataset_folder = tmp_path / "rawdata"
+    output_folder = tmp_path / "out"
+    tiff_name = "recording.tif"
+    _create_dummy_tiff(dataset_folder / tiff_name)
+    mock_parse.return_value = None
+
+    stiminterpolation.run(
+        dataset_folder=dataset_folder,
+        output_folder=output_folder,
+        tiff_name=tiff_name,
+        path_to_stim_h5="",
+        save_metadata=False,
+    )
+
+    _, kwargs = mock_run.call_args
+    assert kwargs["input_h5"] is None
+
+
+@patch("photon_mosaic.preprocessing.stiminterpolation.parse_si_metadata")
+@patch("photon_mosaic.preprocessing.stiminterpolation.run_stiminterp")
+def test_string_path_inputs_are_coerced_to_path(
+    mock_run, mock_parse, tmp_path
+):
+    """str inputs for dataset_folder / output_folder must be accepted."""
+    dataset_folder = tmp_path / "rawdata"
+    output_folder = tmp_path / "out"
+    tiff_name = "recording.tif"
+    _create_dummy_tiff(dataset_folder / tiff_name)
+    mock_parse.return_value = None
+
+    stiminterpolation.run(
+        dataset_folder=str(dataset_folder),
+        output_folder=str(output_folder),
+        tiff_name=tiff_name,
+        save_metadata=False,
+    )
+
+    assert output_folder.is_dir()
+    _, kwargs = mock_run.call_args
+    assert kwargs["output_tif"] == str(
+        output_folder / "stiminterpolated_recording.tif"
+    )


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
In all-optical experiments, using simultaneous calcium imaging and holographic photostimulation, photostimulation often saturates PMTs and causes data loss. 

**What does this PR do?**
This PR adds new preprocessing pipeline which uses [stiminterp](https://github.com/SainsburyWellcomeCentre/stiminterp/tree/main) to run 1D interpolation for removing photostimulation artefacts from calcium imaging data.
<img width="1401" height="811" alt="output" src="https://github.com/user-attachments/assets/b4395ace-fda0-467d-837a-81bb9ec37b5e" />
This could be directly incorporated into [photon-mosaic](https://github.com/photon-mosaic/photon-mosaic) in the near future

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
