### PR TITLE
docs: add postprocessing page and clean up stale references

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ The goal of `photon-mosaic` is to provide a modular, extensible, and user-friend
 - Preprocessing: [derotation](https://github.com/neuroinformatics-unit/derotation) and contrast enhancement (see `photon_mosaic/preprocessing`).
 - Registration & source extraction using [Suite2p](https://github.com/MouseLand/suite2p).
 - Cell detection / anatomical ROI extraction using [Cellpose (v3 or v4, including Cellpose-SAM)](https://github.com/MouseLand/cellpose).
+- Linear neuropil correction (`Fc = F - neucoeff * (Fneu - median(Fneu))`).
+- dF/F calculation with GMM-based baseline F0 estimation.
 
 ### Planned additions
 - Registration using [NoRMCorre](https://github.com/flatironinstitute/NoRMCorre) for non-rigid motion correction.
 - ROI matching using [ROICat](https://github.com/RichieHakim/ROICaT) for inter-session / inter-plane ROI matching.
-- Neuropil subtraction / decontamination: methods from the [AllenSDK](https://allensdk.readthedocs.io/en/latest/allensdk.brain_observatory.r_neuropil.html) and [AST-model](https://github.com/znamlab/2p-preprocess).
+- Advanced neuropil decontamination: methods from the [AllenSDK](https://allensdk.readthedocs.io/en/latest/allensdk.brain_observatory.r_neuropil.html) and [AST-model](https://github.com/znamlab/2p-preprocess).
 - Spike deconvolution: [OASIS](https://github.com/j-friedrich/OASIS) and [CASCADE](https://github.com/HelmchenLabSoftware/Cascade).
 
 See [issues on GitHub](https://github.com/neuroinformatics-unit/photon-mosaic/issues) and the [project board](https://github.com/orgs/neuroinformatics-unit/projects/17) for more details and participate in planning. Please refer to our [guidelines](https://photon-mosaic.neuroinformatics.dev/contributing.html) to understand how to contribute.

--- a/docs/make_api_index.py
+++ b/docs/make_api_index.py
@@ -41,9 +41,9 @@ This section contains automatically generated documentation for the
 
 """
 
-    # Add module entries for the toctree
+    # Add module entries for the toctree (autosummary writes stubs into api/)
     api_index_content += (
-        "\n".join(f"   {module}" for module in module_entries) + "\n\n"
+        "\n".join(f"   api/{module}" for module in module_entries) + "\n\n"
     )
 
     # Add the autosummary directive

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -12,7 +12,7 @@ and [opening a pull request](#pull-requests).
 ## Creating a development environment
 
 To install ``photon-mosaic`` for development, first the
-[GitHub repository](https://github.com/neuroinformatics-unit/photon-mosaic)
+[GitHub repository](https://github.com/photon-mosaic/photon-mosaic-pipeline)
 should be cloned. Then, you can change-directory
 to the cloned repository and run pip install with the developer tag:
 
@@ -58,7 +58,7 @@ Use the `cross_platform_path` function to construct paths that are compatible wi
 
 Example:
 ```python
-from photon_mosaic.pathing import cross_platform_path
+from photon_mosaic.snakemake_utils import cross_platform_path
 
 rule example:
     input:
@@ -167,7 +167,7 @@ folder and open the `index.html` file.
 ### Editing the documentation
 
 The documentation is hosted using [GitHub Pages](https://pages.github.com/), and the source can be found at
-[GitHub](https://github.com/neuroinformatics-unit/photon-mosaic/tree/main/docs).
+[GitHub](https://github.com/photon-mosaic/photon-mosaic-pipeline/tree/main/docs).
 Most content is found under `docs/source`, where the structure mirrors the rendered website.
 
 To edit a page, please:

--- a/docs/source/user_guide/configuration.md
+++ b/docs/source/user_guide/configuration.md
@@ -65,6 +65,14 @@ suite2p_ops:
   roidetect: true
   anatomical_only: 0
 
+# Neuropil correction (post-Suite2p)
+neuropil_ops:
+  neucoeff: 0.7
+
+# dF/F calculation (post-neuropil)
+dff_ops:
+  gmm_ncomponents: 2
+
 # SLURM settings
 use_slurm: false
 slurm:
@@ -74,7 +82,7 @@ slurm:
   nodes: 1
 ```
 
-For the complete configuration file with all available parameters and detailed comments, see [photon_mosaic/workflow/config.yaml](https://github.com/neuroinformatics-unit/photon-mosaic/blob/main/photon_mosaic/workflow/config.yaml) or the YAML file in `~/.photon_mosaic/config.yaml` generated on first run.
+For the complete configuration file with all available parameters and detailed comments, see [photon_mosaic/workflow/config.yaml](https://github.com/photon-mosaic/photon-mosaic-pipeline/blob/main/photon_mosaic/workflow/config.yaml) or the YAML file in `~/.photon_mosaic/config.yaml` generated on first run.
 
 ## Key Configuration Notes
 
@@ -83,6 +91,9 @@ See the [data input documentation](data_input.md) for the required NeuroBlueprin
 
 ### Preprocessing
 See the [preprocessing documentation](preprocessing.md) for step-specific configuration
+
+### Postprocessing
+See the [postprocessing documentation](postprocessing.md) for the `neuropil_ops` and `dff_ops` keys controlling neuropil correction and dF/F calculation.
 
 ### Suite2p Parameters
 The configuration includes all standard Suite2p parameters plus custom additions:

--- a/docs/source/user_guide/index.md
+++ b/docs/source/user_guide/index.md
@@ -42,4 +42,11 @@ Learn about the preprocessing steps available in photon-mosaic.
 How to organise raw data in NeuroBlueprint format and filter which TIFFs the pipeline processes.
 :::
 
+:::{grid-item-card} 📊 Postprocessing
+:link: postprocessing
+:link-type: doc
+
+Neuropil correction and dF/F calculation applied after Suite2p.
+:::
+
 ::::

--- a/docs/source/user_guide/postprocessing.md
+++ b/docs/source/user_guide/postprocessing.md
@@ -1,0 +1,59 @@
+(user_guide/postprocessing)=
+# Postprocessing
+
+After Suite2p extracts fluorescence traces, `photon-mosaic` runs two post-Suite2p stages on each session: **neuropil correction** and **dF/F calculation**. Both run automatically as part of the workflow; their parameters are exposed in `config.yaml`.
+
+The output layout for one session is:
+
+```
+derivatives/sub-*/ses-*/funcimg/
+├── suite2p/plane0/{F.npy, Fneu.npy, ...}   # from Suite2p
+├── neuropil/plane0/Fc.npy                   # neuropil correction
+└── dff/plane0/dFF.npy                       # dF/F traces
+```
+
+## Neuropil correction
+
+Implemented by the `neuropil` rule (`photon_mosaic/workflow/neuropil.smk`), which calls `calculate_neuropil_correction` in `photon_mosaic/rules/neuropil_run.py`.
+
+- **Inputs:** `suite2p/plane0/F.npy`, `suite2p/plane0/Fneu.npy`
+- **Output:** `neuropil/plane0/Fc.npy`
+- **Formula:** `Fc = F - neucoeff * (Fneu - median(Fneu))`
+
+The median is computed per neuropil trace, so the correction subtracts the modulation of the neuropil signal rather than its absolute level.
+
+### Configuration
+
+```yaml
+neuropil_ops:
+  neucoeff: 0.7   # weight applied to the demedianed neuropil trace
+```
+
+`neucoeff = 0.7` is the standard default in the Suite2p / Pachitariu et al. literature. Lower values trust the raw `F` more; higher values subtract more neuropil contamination.
+
+## dF/F calculation
+
+Implemented by the `dff` rule (`photon_mosaic/workflow/dff.smk`), which calls `calculate_dFF` in `photon_mosaic/rules/dff_run.py`.
+
+- **Input:** `neuropil/plane0/Fc.npy` (from the previous stage)
+- **Output:** `dff/plane0/dFF.npy`
+
+For each cell, baseline fluorescence `F0` is estimated by fitting a Gaussian Mixture Model to the neuropil-corrected trace and taking the mean of the lowest-mean component. `dF/F` is then computed in the standard way as `(Fc - F0) / F0`.
+
+### Configuration
+
+```yaml
+dff_ops:
+  gmm_ncomponents: 2   # number of GMM components used to estimate F0
+```
+
+Two components is the typical choice (one for "baseline" frames, one for "active" frames). Increasing this can help on cells with multiple modes of activity but adds parameters and risks overfitting on short recordings.
+
+## Order of execution
+
+Snakemake resolves dependencies automatically: `dff` requires `neuropil`'s output, which requires `suite2p`'s output. Running `photon-mosaic` produces all three. To re-run only one stage, use `--forcerun`:
+
+```bash
+photon-mosaic --forcerun neuropil    # re-run neuropil + dff (downstream)
+photon-mosaic --forcerun dff         # re-run only dff
+```

--- a/docs/source/user_guide/preprocessing.md
+++ b/docs/source/user_guide/preprocessing.md
@@ -7,7 +7,7 @@ There are three available preprocessing steps:
 - `contrast`: Contrast enhancement using percentile-based contrast stretching.
 - `derotation`: Image derotation using the derotation package.
 
-The are mutually exclusive. To trigger one or the other you need to edit the configuration file.
+These are mutually exclusive. To trigger one or the other you need to edit the configuration file.
 
 ## Available Preprocessing Steps
 


### PR DESCRIPTION
Stacked on top of #90 (`docs/neuroblueprint-input`). Covers the remaining stale or missing pieces in the user guide, plus a real API-reference build bug uncovered while verifying the canonical build command.

## Summary

- **New `user_guide/postprocessing.md`** — documents the neuropil correction and dF/F stages added by #89: formulas, output layout under `derivatives/sub-*/ses-*/funcimg/{neuropil,dff}/plane0/`, the `neuropil_ops.neucoeff` and `dff_ops.gmm_ncomponents` config keys, and `--forcerun` ergonomics for selectively re-running stages.
- **`user_guide/index.md`** — adds a 📊 Postprocessing card alongside the existing ones.
- **`user_guide/configuration.md`** — extends the simplified YAML example with `neuropil_ops` and `dff_ops`, adds a Postprocessing subsection linking to the new page, and updates the deep-link to `config.yaml` to the canonical `photon-mosaic/photon-mosaic-pipeline` URL.
- **`README.md`** — moves linear neuropil correction and GMM-based dF/F from "Planned additions" to "Current features"; the Planned entry is renamed to "Advanced neuropil decontamination" so the AllenSDK / AST-model work is still scoped.
- **`contributing.md`** — same GitHub URL fix in two places (the old `neuroinformatics-unit/photon-mosaic` URL silently 301s, but the canonical name is the right thing to ship); corrects the `cross_platform_path` import (`photon_mosaic.pathing` → `photon_mosaic.snakemake_utils`, the wrong path predates this PR).
- **`user_guide/preprocessing.md`** — typo ("The are" → "These are").

## Bug fix: API reference toctree was empty

While verifying the build with the canonical `make clean api_index.rst html` command from `contributing.md`, the build emitted nine `toctree contains reference to nonexisting document 'photon_mosaic.cli'` (etc.) warnings on every build — and the API sidebar was silently empty for users.

Root cause: `docs/make_api_index.py` wrote an explicit toctree listing modules at the top of `source/` (e.g. `photon_mosaic.cli`), but the `autosummary` directive on the same page used `:toctree: api`, which placed the actual stub `.rst` files under `source/api/`. The toctree therefore resolved to nothing.

One-line fix: prefix the toctree entries with `api/` so they match where autosummary writes the stubs. After the fix:

- All nine `toc.not_readable` warnings gone.
- API sidebar now contains real navigable links to `api/photon_mosaic.cli.html`, etc.
- Build warnings: **21 → 12**. The remaining 12 are genuinely pre-existing (six user_guide pages "not in a toctree" because `user_guide/index.md` uses grid cards rather than a toctree, plus a handful of docstring-quality warnings in the source code) and out of scope here.

## Coordination with #89

This PR's user_guide content describes the post-#89 reality. If #89 lands first the docs are immediately accurate; if this lands first the new page just describes rules that exist on the next merge. No code is touched here.

## Test plan

- [x] `make clean api_index.rst html` (canonical command per `contributing.md`) builds successfully.
- [x] API toctree warnings (`toc.not_readable` × 9) are gone after the `make_api_index.py` fix.
- [x] Generated `build/html/api_index.html` contains live links to `api/photon_mosaic.<module>.html` files; the API sidebar is populated.
- [ ] Reviewer opens `docs/build/html/user_guide/postprocessing.html` to sanity-check wording.
- [ ] Reviewer confirms the README "Current features" list reads correctly after the move.
- [ ] Once #90 merges, rebase this branch onto `main` so the base flips back to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
