### PR TITLE
docs: clean up sphinx build warnings (closes #73)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,6 +76,10 @@ templates_path = ["_templates"]
 # Automatically generate stub pages for API
 autosummary_generate = True
 numpydoc_class_members_toctree = False  # stops stubs warning
+# Don't enumerate inherited members in each class' Attributes/Methods summary.
+# Otherwise numpydoc lists ``logging.Formatter.converter`` (== ``time.localtime``)
+# on ``ColoredFormatter``, which autodoc cannot introspect (spurious warning).
+numpydoc_show_inherited_class_members = False
 #toc_object_entries_show_parents = "all"
 html_show_sourcelink = False
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -5,11 +5,6 @@
 :end-before: '## Installation'
 ```
 
-```{include} ../../README.md
-:start-after: '&nbsp;'
-:end-before: '## Installation'
-```
-
 ```{toctree}
 :maxdepth: 2
 :hidden:

--- a/docs/source/user_guide/index.md
+++ b/docs/source/user_guide/index.md
@@ -51,5 +51,5 @@ installation
 configuration
 snakemake_tutorial
 preprocessing
-dataset_discovery
+data_input
 ```

--- a/docs/source/user_guide/index.md
+++ b/docs/source/user_guide/index.md
@@ -43,3 +43,13 @@ How to organise raw data in NeuroBlueprint format and filter which TIFFs the pip
 :::
 
 ::::
+
+```{toctree}
+:hidden:
+
+installation
+configuration
+snakemake_tutorial
+preprocessing
+dataset_discovery
+```

--- a/docs/source/user_guide/installation.md
+++ b/docs/source/user_guide/installation.md
@@ -1,5 +1,5 @@
 (user_guide/installation)=
-## Installation
+# Installation
 
 ```{include} ../../../README.md
 :start-after: '## Installation'

--- a/photon_mosaic/cli.py
+++ b/photon_mosaic/cli.py
@@ -479,8 +479,11 @@ def main():
     store their data on servers connected to HPC clusters and want to
     batch-process multiple imaging sessions in parallel.
 
-    Command Line Arguments
-    ---------------------
+    Notes
+    -----
+    The pipeline is invoked via the ``photon-mosaic`` CLI. The supported
+    command-line arguments are:
+
     --config : str, optional
         Path to your config.yaml file. If not provided, uses
         ~/.photon_mosaic/config.yaml.
@@ -505,9 +508,8 @@ def main():
     extra : list
         Additional arguments to pass to snakemake.
 
-    Notes
-    -----
-    The pipeline will:
+    On each invocation, the pipeline will:
+
     1. Create a timestamped config file in derivatives/photon-mosaic/configs/
     2. Save execution logs in derivatives/photon-mosaic/logs/
     3. Process all TIFF files found under rawdata/sub-*/ses-*/funcimg/

--- a/photon_mosaic/cli.py
+++ b/photon_mosaic/cli.py
@@ -510,9 +510,10 @@ def main():
 
     On each invocation, the pipeline will:
 
-    1. Create a timestamped config file in derivatives/photon-mosaic/configs/
-    2. Save execution logs in derivatives/photon-mosaic/logs/
-    3. Process all TIFF files found under rawdata/sub-*/ses-*/funcimg/
+    1. Create a timestamped config file in
+       ``derivatives/photon-mosaic/configs/``
+    2. Save execution logs in ``derivatives/photon-mosaic/logs/``
+    3. Process all TIFF files found under ``rawdata/sub-*/ses-*/funcimg/``
     4. Generate standardized outputs following NeuroBlueprint specification
     """
     # Parse command line arguments

--- a/photon_mosaic/paths_selection.py
+++ b/photon_mosaic/paths_selection.py
@@ -25,7 +25,7 @@ def find_raw_data_paths(
     ----------
     project_path : Path
         Root of the project, expected to follow NeuroBlueprint format
-        (i.e. contains a rawdata/sub-*/ses-*/funcimg/ structure).
+        (i.e. contains a ``rawdata/sub-*/ses-*/funcimg/`` structure).
     tiff_patterns : list[str]
         Glob patterns for TIFF files to include (e.g. ``["*_00001.tif"]``).
     exclude_datasets : list[str] | None

--- a/photon_mosaic/paths_selection.py
+++ b/photon_mosaic/paths_selection.py
@@ -27,7 +27,7 @@ def find_raw_data_paths(
         Root of the project, expected to follow NeuroBlueprint format
         (i.e. contains a rawdata/sub-*/ses-*/funcimg/ structure).
     tiff_patterns : list[str]
-        Glob patterns for TIFF files to include (e.g. ["*_00001.tif"]).
+        Glob patterns for TIFF files to include (e.g. ``["*_00001.tif"]``).
     exclude_datasets : list[str] | None
         Regex patterns matched against subject folder names to exclude
         (e.g. ["sub-test", "sub-IAA.*"]).
@@ -96,7 +96,7 @@ def adapt_paths_to_output_pattern(
     all_selected_tiff_paths : list[Path]
         Raw TIFF paths, expected to contain a rawdata component.
     output_pattern : str
-        String to prepend to the output filename (e.g. "motion_corrected_").
+        String to prepend to the output filename (e.g. ``motion_corrected_``).
 
     Returns
     -------

--- a/photon_mosaic/preprocessing/contrast.py
+++ b/photon_mosaic/preprocessing/contrast.py
@@ -41,7 +41,7 @@ def run(
     -------
     None
         The function saves the enhanced image to the output folder with the
-        prefix "enhanced_" and returns nothing.
+        prefix ``enhanced_`` and returns nothing.
 
     Notes
     -----


### PR DESCRIPTION
A series of small fixes to the docs to reduce the number of warnings. They do not affect the appearance of the docs. 