### PR TITLE
Rename project to photon-mosaic-pipeline

### DIFF
--- a/photon_mosaic/cli.py
+++ b/photon_mosaic/cli.py
@@ -301,6 +301,11 @@ def build_snakemake_command(args, config_path):
         # Default to quiet mode unless --verbose is specified
         cmd.append("--quiet")
 
+    if os.getenv("CI"):
+        cmd.append("--nolock")
+        cmd.append("--latency-wait")
+        cmd.append("30")
+
     return cmd
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ deps =
     .[dev]
 passenv =
     USERNAME
+    CI
 commands =
     pytest -v --color=yes --cov=photon_mosaic --cov-report=xml
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "photon-mosaic"
+name = "photon-mosaic-pipeline"
 authors = [{name = "Laura Porta", email= "ucqflpo@ucl.ac.uk"}]
 description = "Automating calcium imaging analysis"
 readme = "README.md"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def run_photon_mosaic():
             "DEBUG",
         ]
 
-        if os.getenv("GITHUB_ACTIONS"):
+        if os.getenv("CI"):
             cmd.append("--nolock")
             cmd.append("--latency-wait 30")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ tests, following the DRY principle to avoid duplication.
 """
 
 import argparse
-import os
 import subprocess
 from datetime import datetime
 from pathlib import Path
@@ -33,10 +32,6 @@ def run_photon_mosaic():
             "--log-level",
             "DEBUG",
         ]
-
-        if os.getenv("CI"):
-            cmd.append("--nolock")
-            cmd.append("--latency-wait 30")
 
         result = subprocess.run(
             cmd,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ tests, following the DRY principle to avoid duplication.
 """
 
 import argparse
+import os
 import subprocess
 from datetime import datetime
 from pathlib import Path
@@ -32,6 +33,10 @@ def run_photon_mosaic():
             "--log-level",
             "DEBUG",
         ]
+
+        if os.getenv("GITHUB_ACTIONS"):
+            cmd.append("--nolock")
+            cmd.append("--latency-wait 30")
 
         result = subprocess.run(
             cmd,

--- a/tests/test_integration/test_whole_workflow.py
+++ b/tests/test_integration/test_whole_workflow.py
@@ -28,7 +28,7 @@ def run_snakemake(workdir, configfile, dry_run=False):
 
     print(" ".join(cmd))
 
-    if os.getenv("GITHUB_ACTIONS"):
+    if os.getenv("CI"):
         cmd.append("--nolock")
         cmd.append("--latency-wait 30")
 

--- a/tests/test_integration/test_whole_workflow.py
+++ b/tests/test_integration/test_whole_workflow.py
@@ -30,7 +30,8 @@ def run_snakemake(workdir, configfile, dry_run=False):
 
     if os.getenv("CI"):
         cmd.append("--nolock")
-        cmd.append("--latency-wait 30")
+        cmd.append("--latency-wait")
+        cmd.append("30")
 
     result = subprocess.run(
         cmd,

--- a/tests/test_integration/test_whole_workflow.py
+++ b/tests/test_integration/test_whole_workflow.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from pathlib import Path
 
@@ -26,6 +27,10 @@ def run_snakemake(workdir, configfile, dry_run=False):
         cmd.insert(1, "--dry-run")
 
     print(" ".join(cmd))
+
+    if os.getenv("GITHUB_ACTIONS"):
+        cmd.append("--nolock")
+        cmd.append("--latency-wait 30")
 
     result = subprocess.run(
         cmd,


### PR DESCRIPTION
To build the wheels for new envisioned PyPI name, we need to rename the project in `pyproject.toml`.