### PR TITLE
Fix CI macOS failure: force Cellpose onto CPU in tests

### DIFF
--- a/photon_mosaic/rules/suite2p_run.py
+++ b/photon_mosaic/rules/suite2p_run.py
@@ -2,12 +2,39 @@
 Snakemake rule for running Suite2P.
 """
 
+import os
 import traceback
 from pathlib import Path
 from typing import Optional
 
 from suite2p import run_s2p
 from suite2p.default_ops import default_ops
+
+
+def _force_cellpose_cpu_if_requested():
+    """Force Cellpose onto CPU when ``PHOTON_MOSAIC_FORCE_CPU=1``.
+
+    Suite2p's anatomical detection runs Cellpose on a GPU whenever
+    ``cellpose.core.use_gpu()`` reports one is available. On a real
+    Apple-Silicon machine the MPS backend works and is the right default, so
+    this is **off by default**. But GitHub-hosted macOS runners expose an MPS
+    device that torch detects and can allocate on, yet which computes
+    Cellpose-SAM incorrectly -- it returns 0 masks, so Suite2p writes no
+    ``F.npy`` and the pipeline fails. Setting ``PHOTON_MOSAIC_FORCE_CPU=1``
+    pins Cellpose to the CPU, which produces correct masks everywhere. The
+    test suite sets this var (see ``tests/conftest.py``); the snakemake
+    subprocesses inherit it.
+    """
+    if os.environ.get("PHOTON_MOSAIC_FORCE_CPU") != "1":
+        return
+    try:
+        import cellpose.core
+
+        cellpose.core.use_gpu = lambda *args, **kwargs: False
+    except Exception:
+        # Cellpose isn't importable (e.g. anatomical detection disabled) --
+        # nothing to force; suite2p will run its non-Cellpose path.
+        pass
 
 
 def run_suite2p(
@@ -39,6 +66,8 @@ def run_suite2p(
         dataset folder.
     """
     save_folder = Path(stat_path).parents[1]
+
+    _force_cellpose_cpu_if_requested()
 
     ops = get_edited_options(
         input_path=dataset_folder,

--- a/photon_mosaic/rules/suite2p_run.py
+++ b/photon_mosaic/rules/suite2p_run.py
@@ -31,7 +31,7 @@ def _force_cellpose_cpu_if_requested():
         import cellpose.core
 
         cellpose.core.use_gpu = lambda *args, **kwargs: False
-    except Exception:
+    except ImportError:
         # Cellpose isn't importable (e.g. anatomical detection disabled) --
         # nothing to force; suite2p will run its non-Cellpose path.
         pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ tests, following the DRY principle to avoid duplication.
 """
 
 import argparse
+import os
 import subprocess
 from datetime import datetime
 from pathlib import Path
@@ -15,6 +16,16 @@ import yaml
 
 from tests.test_data_factory import DataFactory
 from tests.tree_helpers import tree as tree_lines
+
+# On CI, pin Cellpose to the CPU. The integration tests run the pipeline by
+# spawning snakemake as a subprocess (which inherits os.environ), and
+# GitHub-hosted macOS runners expose a non-functional MPS device that makes
+# Cellpose-SAM return 0 masks -> Suite2p writes no F.npy -> the workflow
+# fails. We gate on CI so local test runs keep using a working GPU/MPS (much
+# faster); the env var is also a manual override anywhere. See
+# photon_mosaic.rules.suite2p_run._force_cellpose_cpu_if_requested.
+if os.environ.get("CI"):
+    os.environ.setdefault("PHOTON_MOSAIC_FORCE_CPU", "1")
 
 
 @pytest.fixture


### PR DESCRIPTION
GitHub-hosted macOS runners expose an MPS device that torch detects and can allocate on, but which computes Cellpose-SAM incorrectly (0 masks), so suite2p writes no F.npy and the snakemake workflow fails. Real Apple-Silicon hardware has working MPS and is unaffected.

Add an env-gated hook (PHOTON_MOSAIC_FORCE_CPU=1, off by default) in run_suite2p that pins Cellpose to the CPU before run_s2p, and set the env var in tests/conftest.py so the Snakemake subprocesses (spawned via subprocess.run, inheriting os.environ) force CPU during tests on CI.