### PR TITLE
Remove self-referencing link from linkcheck ignore

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -193,8 +193,4 @@ linkcheck_ignore = [
     "https://neuroinformatics.zulipchat.com/#narrow/channel/500681-photon-mosaic",
     "https://www.sciencedirect.com/science/article/pii/S089662731930889X",
     "https://pipeline.photon-mosaic.org/*",
-    # Self-reference to a path under the renamed package dir. It only exists
-    # on `main` once this rename PR merges, so linkcheck 404s until then.
-    # Safe to remove after merge.
-    "https://github.com/photon-mosaic/photon-mosaic-pipeline/blob/main/photon_mosaic_pipeline/.*",
 ]


### PR DESCRIPTION
Because it now exists post-renaming.

Tiny follow up on #105 before we forget :grin: 